### PR TITLE
Add setProxy method, optimize tests, and introduce TestHelper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /composer.lock
-/vendor/
+vendor/
 /*.cache
+.idea/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.1.0] - 2023-03-17
+
+### Added
+
+- `setProxy()` method added to the `OpenAI` class, allowing users to set a custom proxy for the underlying HTTP client.
+- New `TestHelper` class to simplify test code and improve readability. Includes methods to work with private properties and methods using Reflection, as well as a method to load response files for testing purposes.
+- Unit tests and optimizations for the new features in `OpenAITest.php`.
+
+### Changed
+
+- Optimized several test methods in `OpenAITest.php` by leveraging the newly created `TestHelper` class.
+
+## [1.0.0] - 2023-03-16
+
+### Added
+
+- Initial release of the OpenAI PHP library.
+- Basic implementation for making API calls to the OpenAI API.
+- Unit tests for the initial implementation.

--- a/README.md
+++ b/README.md
@@ -129,6 +129,10 @@ For more details on how to use each endpoint, refer to the [OpenAI API documenta
 -   [Create moderation](https://platform.openai.com/docs/api-reference/moderations/create) - [Example](https://github.com/SoftCreatR/php-openai-sdk/blob/main/examples/moderations/createModeration.php)
     -   `createModeration(array $options = [])`
 
+## Changelog
+
+For a detailed list of changes and updates, please refer to the [CHANGELOG.md](https://github.com/SoftCreatR/php-openai-sdk/blob/main/CHANGELOG.md) file. We adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) and document notable changes for each release.
+
 ## Known Problems and limitations
 
 ### Streaming Support

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "A powerful and easy-to-use PHP SDK for the OpenAI API, allowing seamless integration of advanced AI-powered features into your PHP projects.",
   "license": "ISC",
   "type": "library",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "keywords": [
     "openai",
     "gpt",
@@ -39,7 +39,7 @@
   },
   "autoload-dev": {
     "psr-4": {
-      "SoftCreatr\\OpenAI\\Tests\\": "tests/"
+      "SoftCreatR\\OpenAI\\Tests\\": "tests/"
     }
   },
   "config": {

--- a/tests/OpenAIUrlFactoryTest.php
+++ b/tests/OpenAIUrlFactoryTest.php
@@ -1,5 +1,21 @@
 <?php
 
+/*
+ * Copyright (c) 2023, Sascha Greuel and Contributors
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
 namespace SoftCreatR\OpenAI\Tests;
 
 use InvalidArgumentException;

--- a/tests/TestHelper.php
+++ b/tests/TestHelper.php
@@ -1,0 +1,93 @@
+<?php
+
+/*
+ * Copyright (c) 2023, Sascha Greuel and Contributors
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+namespace SoftCreatR\OpenAI\Tests;
+
+use ReflectionClass;
+use ReflectionException;
+use ReflectionMethod;
+
+class TestHelper
+{
+    /**
+     * Get a private property of an object using Reflection.
+     *
+     * @param object $instance The instance of the object.
+     * @param string $propertyName The name of the private property.
+     *
+     * @return mixed The value of the private property.
+     *
+     * @throws ReflectionException If the property does not exist.
+     */
+    public static function getPrivateProperty(object $instance, string $propertyName)
+    {
+        $reflection = new ReflectionClass($instance);
+        $property = $reflection->getProperty($propertyName);
+        $property->setAccessible(true);
+
+        return $property->getValue($instance);
+    }
+
+    /**
+     * Set the value of a private property of an object using Reflection.
+     *
+     * @param object $instance The instance of the object.
+     * @param string $propertyName The name of the private property.
+     * @param mixed $value The value to set.
+     *
+     * @throws ReflectionException If the property does not exist.
+     */
+    public static function setPrivateProperty(object $instance, string $propertyName, $value): void
+    {
+        $reflection = new ReflectionClass($instance);
+        $property = $reflection->getProperty($propertyName);
+        $property->setAccessible(true);
+        $property->setValue($instance, $value);
+    }
+
+    /**
+     * Get a private method of an object using Reflection.
+     *
+     * @param object $instance The instance of the object.
+     * @param string $methodName The name of the private method.
+     *
+     * @return ReflectionMethod The private method.
+     *
+     * @throws ReflectionException If the method does not exist.
+     */
+    public static function getPrivateMethod(object $instance, string $methodName): ReflectionMethod
+    {
+        $reflection = new ReflectionClass($instance);
+        $method = $reflection->getMethod($methodName);
+        $method->setAccessible(true);
+
+        return $method;
+    }
+
+    /**
+     * Load the content of a response file for testing.
+     *
+     * @param string $filename The name of the response file.
+     *
+     * @return string The content of the response file.
+     */
+    public static function loadResponseFromFile(string $filename): string
+    {
+        return \file_get_contents(__DIR__ . '/responses/' . $filename);
+    }
+}


### PR DESCRIPTION
# 🔀 Pull Request

## What does this PR do?

This PR introduces several improvements to the OpenAI PHP library:

1.  Adds a new `setProxy()` method to the `OpenAI` class, allowing users to set a custom proxy for the underlying HTTP client.
2.  Improves and optimizes test methods in `OpenAITest.php` by leveraging the newly created `TestHelper` class.
3.  Introduces a new `TestHelper` class to simplify test code and improve readability. This class includes methods to work with private properties and methods using Reflection, as well as a method to load response files for testing purposes.
4. Added CHANGELOG.md to track changes

## Test Plan

To verify the changes in this PR, follow these steps:

1.  Run the unit tests with the updated test methods in `OpenAITest.php`. All tests should pass, and the code coverage should remain the same or improve.
2.  Review the `setProxy()` method implementation in `OpenAI.php` and ensure it works as expected with the HTTP client.
3.  Test the new `setProxy()` method in a sample project, and verify that the proxy setting is applied correctly.
4.  Check the `TestHelper` class and ensure the provided methods work as expected for their use cases in the tests.

Note: Remember to provide any necessary API keys or other credentials when running tests or sample projects.